### PR TITLE
Accessibility: add visible button focus

### DIFF
--- a/placeholder.js
+++ b/placeholder.js
@@ -1,0 +1,33 @@
+let Selector = require('../selector')
+
+class Placeholder extends Selector {
+  /**
+   * Add old mozilla to possible prefixes
+   */
+  possible() {
+    return super.possible().concat(['-moz- old', '-ms- old'])
+  }
+
+  /**
+   * Return different selectors depend on prefix
+   */
+  prefixed(prefix) {
+    if (prefix === '-webkit-') {
+      return '::-webkit-input-placeholder'
+    }
+    if (prefix === '-ms-') {
+      return '::-ms-input-placeholder'
+    }
+    if (prefix === '-ms- old') {
+      return ':-ms-input-placeholder'
+    }
+    if (prefix === '-moz- old') {
+      return ':-moz-placeholder'
+    }
+    return `::${prefix}placeholder`
+  }
+}
+
+Placeholder.names = ['::placeholder']
+
+module.exports = Placeholder


### PR DESCRIPTION
Adds a visible focus ring to primary and secondary buttons to improve keyboard navigation and accessibility. Updates button CSS (buttons.scss) to include a consistent box-shadow and outline-offset on :focus states without altering hover styles or layout.